### PR TITLE
feat(mobile): custom pull-to-refresh with rotating triskelion loader

### DIFF
--- a/apps/mobile/src/core/presentation/components/PullToRefreshIndicator.tsx
+++ b/apps/mobile/src/core/presentation/components/PullToRefreshIndicator.tsx
@@ -1,0 +1,134 @@
+import { useEffect } from "react";
+
+import Animated, {
+  cancelAnimation,
+  Easing,
+  Extrapolation,
+  interpolate,
+  type SharedValue,
+  useAnimatedStyle,
+  useSharedValue,
+  withDelay,
+  withRepeat,
+  withSequence,
+  withTiming,
+} from "react-native-reanimated";
+import { StyleSheet } from "react-native-unistyles";
+
+type TProps = {
+  scrollY: SharedValue<number>;
+  refreshing: boolean;
+  threshold: number;
+};
+
+const DOT_SIZE = 10;
+const ORBIT_RADIUS = 13;
+const CONTAINER_SIZE = (ORBIT_RADIUS + DOT_SIZE) * 2;
+const SPIN_MS = 1200;
+const PULSE_MS = 500;
+const STAGGER_MS = 140;
+const PULL_REVEAL_RATIO = 0.4;
+
+const DOT_POSITIONS = [
+  { key: "top", x: 0, y: -ORBIT_RADIUS },
+  { key: "bottom-right", x: ORBIT_RADIUS * Math.cos(Math.PI / 6), y: ORBIT_RADIUS * Math.sin(Math.PI / 6) },
+  { key: "bottom-left", x: -ORBIT_RADIUS * Math.cos(Math.PI / 6), y: ORBIT_RADIUS * Math.sin(Math.PI / 6) },
+] as const;
+
+export const PullToRefreshIndicator = ({ scrollY, refreshing, threshold }: TProps) => {
+  const spin = useSharedValue(0);
+  const refreshProgress = useSharedValue(0);
+  const pulse0 = useSharedValue(1);
+  const pulse1 = useSharedValue(1);
+  const pulse2 = useSharedValue(1);
+
+  useEffect(() => {
+    refreshProgress.value = withTiming(refreshing ? 1 : 0, { duration: 220 });
+
+    const pulses = [pulse0, pulse1, pulse2];
+
+    if (refreshing) {
+      spin.value = 0;
+      spin.value = withRepeat(withTiming(360, { duration: SPIN_MS, easing: Easing.linear }), -1);
+
+      pulses.forEach((p, i) => {
+        p.value = withDelay(
+          i * STAGGER_MS,
+          withRepeat(
+            withSequence(
+              withTiming(1.25, { duration: PULSE_MS / 2, easing: Easing.inOut(Easing.quad) }),
+              withTiming(0.7, { duration: PULSE_MS / 2, easing: Easing.inOut(Easing.quad) }),
+            ),
+            -1,
+            true,
+          ),
+        );
+      });
+    } else {
+      cancelAnimation(spin);
+      spin.value = withTiming(0, { duration: 200 });
+      for (const p of pulses) {
+        cancelAnimation(p);
+        p.value = withTiming(1, { duration: 200 });
+      }
+    }
+  }, [refreshing, spin, refreshProgress, pulse0, pulse1, pulse2]);
+
+  const containerStyle = useAnimatedStyle(() => {
+    const pull = -scrollY.value;
+    const pullScale = interpolate(pull, [0, threshold], [0.4, 1], Extrapolation.CLAMP);
+    const pullOpacity = interpolate(pull, [0, threshold * PULL_REVEAL_RATIO], [0, 1], Extrapolation.CLAMP);
+
+    const opacity = Math.max(pullOpacity, refreshProgress.value);
+    const scale = Math.max(pullScale * (pullOpacity > 0 ? 1 : 0), refreshProgress.value);
+
+    return {
+      opacity,
+      transform: [{ scale }, { rotate: `${spin.value}deg` }],
+    };
+  });
+
+  const dotPulses = [pulse0, pulse1, pulse2];
+
+  return (
+    <Animated.View style={[styles.container, containerStyle]} pointerEvents="none">
+      {DOT_POSITIONS.map((pos, i) => (
+        <Dot key={pos.key} x={pos.x} y={pos.y} pulse={dotPulses[i]} />
+      ))}
+    </Animated.View>
+  );
+};
+
+type TDotProps = {
+  x: number;
+  y: number;
+  pulse: SharedValue<number>;
+};
+
+const Dot = ({ x, y, pulse }: TDotProps) => {
+  const animatedStyle = useAnimatedStyle(() => ({
+    transform: [{ translateX: x }, { translateY: y }, { scale: pulse.value }],
+  }));
+  return <Animated.View style={[styles.dot, animatedStyle]} />;
+};
+
+const styles = StyleSheet.create((theme) => ({
+  container: {
+    position: "absolute",
+    top: 0,
+    left: 0,
+    right: 0,
+    alignItems: "center",
+    justifyContent: "center",
+    height: CONTAINER_SIZE,
+    zIndex: 5,
+  },
+
+  dot: {
+    position: "absolute",
+    width: DOT_SIZE,
+    height: DOT_SIZE,
+    borderRadius: DOT_SIZE / 2,
+    backgroundColor: theme.primary,
+  },
+}));

--- a/apps/mobile/src/core/presentation/components/PullToRefreshScrollView.tsx
+++ b/apps/mobile/src/core/presentation/components/PullToRefreshScrollView.tsx
@@ -1,0 +1,87 @@
+import type React from "react";
+import { useEffect } from "react";
+import { View } from "react-native";
+
+import { PullToRefreshIndicator } from "core/presentation/components/PullToRefreshIndicator";
+import Animated, {
+  type AnimatedRef,
+  runOnJS,
+  type SharedValue,
+  useAnimatedRef,
+  useAnimatedScrollHandler,
+  useAnimatedStyle,
+  useSharedValue,
+  withTiming,
+} from "react-native-reanimated";
+import { StyleSheet } from "react-native-unistyles";
+
+const DEFAULT_THRESHOLD = 80;
+const REFRESH_GAP = 60;
+
+type TAnimatedScrollViewProps = React.ComponentProps<typeof Animated.ScrollView>;
+
+type TProps = Omit<TAnimatedScrollViewProps, "refreshControl" | "ref" | "onScroll" | "children"> & {
+  refreshing: boolean;
+  onRefresh: () => void;
+  scrollRef?: AnimatedRef<Animated.ScrollView>;
+  scrollOffset?: SharedValue<number>;
+  threshold?: number;
+  children?: React.ReactNode;
+};
+
+export const PullToRefreshScrollView = ({
+  refreshing,
+  onRefresh,
+  scrollRef: externalRef,
+  scrollOffset: externalScrollOffset,
+  threshold = DEFAULT_THRESHOLD,
+  children,
+  ...rest
+}: TProps) => {
+  const internalRef = useAnimatedRef<Animated.ScrollView>();
+  const ref = externalRef ?? internalRef;
+
+  const internalScrollOffset = useSharedValue(0);
+  const scrollOffset = externalScrollOffset ?? internalScrollOffset;
+  const triggered = useSharedValue(false);
+  const gap = useSharedValue(0);
+
+  useEffect(() => {
+    gap.value = withTiming(refreshing ? REFRESH_GAP : 0, { duration: 240 });
+  }, [refreshing, gap]);
+
+  const scrollHandler = useAnimatedScrollHandler({
+    onScroll: (event) => {
+      scrollOffset.value = event.contentOffset.y;
+    },
+    onBeginDrag: () => {
+      triggered.value = false;
+    },
+    onEndDrag: (event) => {
+      if (event.contentOffset.y < -threshold && !triggered.value) {
+        triggered.value = true;
+        runOnJS(onRefresh)();
+      }
+    },
+  });
+
+  const spacerStyle = useAnimatedStyle(() => ({
+    height: gap.value,
+  }));
+
+  return (
+    <View style={styles.root}>
+      <PullToRefreshIndicator scrollY={scrollOffset} refreshing={refreshing} threshold={threshold} />
+      <Animated.ScrollView {...rest} ref={ref} onScroll={scrollHandler} scrollEventThrottle={16}>
+        <Animated.View style={spacerStyle} />
+        {children}
+      </Animated.ScrollView>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create(() => ({
+  root: {
+    flex: 1,
+  },
+}));

--- a/apps/mobile/src/core/presentation/components/index.ts
+++ b/apps/mobile/src/core/presentation/components/index.ts
@@ -14,6 +14,8 @@ export { NetworkIcon } from "./NetworkIcon";
 export { NetworkStack } from "./NetworkStack";
 export { ProtocolIcon } from "./ProtocolIcon";
 export { ProtocolStrip } from "./ProtocolStrip";
+export { PullToRefreshIndicator } from "./PullToRefreshIndicator";
+export { PullToRefreshScrollView } from "./PullToRefreshScrollView";
 export { SegmentedControl } from "./SegmentedControl";
 export { SidebarItem } from "./SidebarItem";
 export { Skeleton } from "./Skeleton";

--- a/apps/mobile/src/features/uniswap-v3/presentation/components/PositionDetailView.tsx
+++ b/apps/mobile/src/features/uniswap-v3/presentation/components/PositionDetailView.tsx
@@ -5,7 +5,7 @@ import { Box, Stack } from "@grapp/stacks";
 import { CHAIN_BY_ID } from "core/config/chains";
 import { container } from "core/di/container";
 import { OpenExternalLinkUseCase } from "core/linking";
-import { Button, Card, Divider, ProtocolStrip, Text } from "core/presentation/components";
+import { Button, Card, Divider, ProtocolStrip, PullToRefreshScrollView, Text } from "core/presentation/components";
 import { formatUsd, truncateAddress } from "core/presentation/utils/format";
 import { PositionHeroCard } from "features/uniswap-v3/presentation/components/PositionHeroCard";
 import { PositionStickyPill } from "features/uniswap-v3/presentation/components/PositionStickyPill";
@@ -13,11 +13,14 @@ import type { PositionDetailVM } from "positions/data/fixtures/positions.fixture
 import { AiPredictCard } from "positions/presentation/components/AiPredictCard";
 import { StatRow } from "positions/presentation/components/StatRow";
 import { TokenAmountRow } from "positions/presentation/components/TokenAmountRow";
-import Animated, { useAnimatedRef, useScrollOffset, useSharedValue } from "react-native-reanimated";
+import type Animated from "react-native-reanimated";
+import { useAnimatedRef, useSharedValue } from "react-native-reanimated";
 import { StyleSheet } from "react-native-unistyles";
 
 type TProps = {
   position: PositionDetailVM;
+  refreshing: boolean;
+  onRefresh: () => void;
 };
 
 const uniswapPositionUrl = (chainId: number, id: string): string | null => {
@@ -26,9 +29,9 @@ const uniswapPositionUrl = (chainId: number, id: string): string | null => {
   return `https://app.uniswap.org/positions/v3/${chain.key}/${id}`;
 };
 
-export const PositionDetailView = ({ position }: TProps) => {
+export const PositionDetailView = ({ position, refreshing, onRefresh }: TProps) => {
   const animatedRef = useAnimatedRef<Animated.ScrollView>();
-  const scrollOffset = useScrollOffset(animatedRef);
+  const scrollOffset = useSharedValue(0);
   const heroEndY = useSharedValue(0);
 
   const onHeroLayout = (e: LayoutChangeEvent) => {
@@ -46,11 +49,13 @@ export const PositionDetailView = ({ position }: TProps) => {
 
   return (
     <View style={styles.root}>
-      <Animated.ScrollView
-        ref={animatedRef}
+      <PullToRefreshScrollView
+        scrollRef={animatedRef}
+        scrollOffset={scrollOffset}
+        refreshing={refreshing}
+        onRefresh={onRefresh}
         contentContainerStyle={styles.content}
         contentInsetAdjustmentBehavior="automatic"
-        scrollEventThrottle={16}
       >
         <View onLayout={onHeroLayout}>
           <PositionHeroCard position={position} />
@@ -99,7 +104,7 @@ export const PositionDetailView = ({ position }: TProps) => {
             />
           )}
         </Stack>
-      </Animated.ScrollView>
+      </PullToRefreshScrollView>
 
       <PositionStickyPill position={position} scrollOffset={scrollOffset} heroEndY={heroEndY} />
     </View>

--- a/apps/mobile/src/positions/presentation/screens/PositionDetailScreen.tsx
+++ b/apps/mobile/src/positions/presentation/screens/PositionDetailScreen.tsx
@@ -17,7 +17,7 @@ type TProps = {
 
 export const PositionDetailScreen = observer(({ id }: TProps) => {
   const router = useRouter();
-  const { data: position, isLoading } = usePositionByIdQuery(id);
+  const { data: position, isLoading, isRefetching, refetch } = usePositionByIdQuery(id);
   const followingStore = container.resolve(FollowingStore);
 
   if (isLoading) {
@@ -63,7 +63,15 @@ export const PositionDetailScreen = observer(({ id }: TProps) => {
       {(() => {
         switch (position.protocol) {
           case "uniswap-v3":
-            return <PositionDetailView position={position} />;
+            return (
+              <PositionDetailView
+                position={position}
+                refreshing={isRefetching}
+                onRefresh={() => {
+                  refetch();
+                }}
+              />
+            );
         }
       })()}
     </>


### PR DESCRIPTION
## Summary

Adds a reusable `PullToRefreshScrollView` wrapper around `Animated.ScrollView` so the position detail screen can have a custom pull-to-refresh animation instead of the system spinner.

- During pull-down: a three-dot triangle (`theme.primary`) reveals and scales with the pull progress.
- During refresh: the whole triangle rotates linearly while each dot pulses staggered.
- An animated 60px "pocket" opens at the top of the scroll content while refreshing, so the indicator never overlaps the content area; it slides back closed once the refetch completes.

Wired into `PositionDetailScreen` → `PositionDetailView`. Scope is intentionally limited to refetching the current position via `usePositionByIdQuery`. Other screens (Positions, Wallets, Following) are not touched.

## Why draft

The wiring uses the same mock-backed query as the rest of the detail screen, so refetch is effectively a no-op against fixtures. Holding this in draft until real (non-mock) data lands — at that point we can verify timing, loading durations, and decide which other screens get the component.

## Test plan

- [ ] iOS simulator: open position detail, pull down past threshold, confirm triangle reveals + scales, dots rotate + pulse on refresh, content slides down 60px and back without jank.
- [ ] iOS simulator: confirm sticky pill above hero card still reveals correctly during/after refresh (heroEndY relayouts when spacer opens).
- [ ] Android emulator: confirm spacer doesn't cause flicker on first mount; verify Easing.linear rotation runs at 60fps.
- [ ] Light/dark theme: verify dot color picks up `theme.primary` correctly in both.
- [ ] Cold start the screen multiple times to confirm no leaked `withRepeat` animations after unmount.