### PR TITLE
refactor(server): static factories + typed context for domain errors

### DIFF
--- a/apps/server/src/features/uniswap-v3/app/get-position.usecase.ts
+++ b/apps/server/src/features/uniswap-v3/app/get-position.usecase.ts
@@ -5,7 +5,7 @@ import type { PositionFeesCache } from "../data/position-fees.cache";
 import { PositionsRepository } from "../data/positions.repository";
 import { POSITION_FEES_CACHE } from "../di/tokens";
 import type { PositionEntity } from "../domain/entities/position.entity";
-import { PositionError } from "../domain/errors/position.error";
+import type { PositionError } from "../domain/errors/position.error";
 import type { ComputedFees } from "../domain/utils/fee-math";
 import { computeUnclaimedFees } from "../domain/utils/fee-math";
 import { type MapPositionResult, type MapperUnclaimedFees, mapV3PositionToContract } from "../presentation/mappers/position.mapper";
@@ -30,7 +30,7 @@ export class GetPositionUseCase {
     const dto = result.value;
 
     const poolStateResult = await this.positionsRepository.getPoolState(dto.pool.id);
-    if (poolStateResult.isErr()) return err(new PositionError(PositionError.CODE.UNEXPECTED_ERROR));
+    if (poolStateResult.isErr()) return err(poolStateResult.error);
 
     const entity = dto.toDomain(poolStateResult.value);
 

--- a/apps/server/src/features/uniswap-v3/data/positions.repository.ts
+++ b/apps/server/src/features/uniswap-v3/data/positions.repository.ts
@@ -49,19 +49,19 @@ export class PositionsRepository extends BaseRepository {
       const result = await this.gql.request(getWalletPositionsQuery, { owner, ...pagination, ...filters });
       const positions = result.positions.map((p) => GraphQLPositionDto.fromGraphQL(p, this.chainContext.chain.id));
       return ok(positions);
-    } catch {
-      return err(new PositionError(PositionError.CODE.GRAPHQL_ERROR));
+    } catch (error) {
+      return err(PositionError.GRAPHQL_ERROR({ error, context: { owner, ...pagination } }));
     }
   }
 
   async getPosition(id: string) {
     try {
       const result = await this.gql.request(getPositionQuery, { id });
-      if (!result.position) return err(new PositionError(PositionError.CODE.POSITION_NOT_FOUND));
+      if (!result.position) return err(PositionError.POSITION_NOT_FOUND({ context: { id } }));
       const position = GraphQLPositionDto.fromGraphQL(result.position, this.chainContext.chain.id);
       return ok(position);
-    } catch {
-      return err(new PositionError(PositionError.CODE.GRAPHQL_ERROR));
+    } catch (error) {
+      return err(PositionError.GRAPHQL_ERROR({ error, context: { id } }));
     }
   }
 
@@ -69,7 +69,7 @@ export class PositionsRepository extends BaseRepository {
     const result = await this.getPoolStates([poolAddress]);
     if (result.isErr()) return err(result.error);
     const state = result.value.get(poolAddress);
-    if (!state) return err(new PositionError(PositionError.CODE.UNEXPECTED_ERROR));
+    if (!state) return err(PositionError.UNEXPECTED_ERROR({ message: "Pool state missing after multicall", context: { poolAddress } }));
     return ok(state);
   }
 
@@ -87,8 +87,8 @@ export class PositionsRepository extends BaseRepository {
         if (address) map.set(address, { sqrtPriceX96: slot0[0], currentTick: slot0[1], liquidity });
       }
       return ok(map);
-    } catch {
-      return err(new PositionError(PositionError.CODE.UNEXPECTED_ERROR));
+    } catch (error) {
+      return err(PositionError.UNEXPECTED_ERROR({ error, context: { poolAddresses: unique } }));
     }
   }
 
@@ -96,8 +96,8 @@ export class PositionsRepository extends BaseRepository {
     try {
       const results = await this.rpc.multicall({ contracts: this.buildFeeContracts(position) });
       return ok(parsePositionFeeResult(results));
-    } catch {
-      return err(new PositionError(PositionError.CODE.UNEXPECTED_ERROR));
+    } catch (error) {
+      return err(PositionError.UNEXPECTED_ERROR({ error, context: { positionId: position.id } }));
     }
   }
 
@@ -113,8 +113,8 @@ export class PositionsRepository extends BaseRepository {
         feeDataMap.set(positions[i]!.id, parsePositionFeeResult(results.slice(i * 5, i * 5 + 5)));
       }
       return ok(feeDataMap);
-    } catch {
-      return err(new PositionError(PositionError.CODE.UNEXPECTED_ERROR));
+    } catch (error) {
+      return err(PositionError.UNEXPECTED_ERROR({ error, context: { positionCount: positions.length } }));
     }
   }
 

--- a/apps/server/src/features/uniswap-v3/domain/errors/position.error.ts
+++ b/apps/server/src/features/uniswap-v3/domain/errors/position.error.ts
@@ -1,4 +1,4 @@
-import { DomainError } from "shared/errors/base.error";
+import { DomainError, type DomainErrorOpts } from "shared/errors/base.error";
 
 export enum PositionErrorCode {
   POSITION_NOT_FOUND = "POSITION_NOT_FOUND",
@@ -13,15 +13,26 @@ const errorMessages: Record<PositionErrorCode, string> = {
 };
 
 export class PositionError extends DomainError<PositionErrorCode> {
-  static readonly CODE = PositionErrorCode;
-  name = "PositionError";
+  static readonly CODES = PositionErrorCode;
 
-  constructor(code: PositionErrorCode, message?: string, context: Record<string, unknown> = {}) {
+  constructor(code: PositionErrorCode, message?: string, context?: Record<string, unknown>) {
     super(code, message ?? errorMessages[code], context);
   }
 
   get isNotFound(): boolean {
     return this.code === PositionErrorCode.POSITION_NOT_FOUND;
+  }
+
+  static POSITION_NOT_FOUND(opts?: DomainErrorOpts) {
+    return PositionError.create(PositionError.CODES.POSITION_NOT_FOUND, opts);
+  }
+
+  static GRAPHQL_ERROR(opts?: DomainErrorOpts) {
+    return PositionError.create(PositionError.CODES.GRAPHQL_ERROR, opts);
+  }
+
+  static UNEXPECTED_ERROR(opts?: DomainErrorOpts) {
+    return PositionError.create(PositionError.CODES.UNEXPECTED_ERROR, opts);
   }
 
   static isInstance(error: unknown): error is PositionError {

--- a/apps/server/src/shared/errors/base.error.ts
+++ b/apps/server/src/shared/errors/base.error.ts
@@ -1,15 +1,33 @@
-export abstract class DomainError<TCode extends string = string> extends Error {
-  constructor(
-    public readonly code: TCode,
-    message: string,
-    public readonly context: Record<string, unknown> = {},
-  ) {
+export type DomainErrorOpts<TContext extends Record<string, unknown> = Record<string, unknown>> = {
+  message?: string;
+  error?: unknown;
+  context?: TContext;
+};
+
+export abstract class DomainError<
+  TCode extends string = string,
+  TContext extends Record<string, unknown> = Record<string, unknown>,
+> extends Error {
+  public readonly code: TCode;
+  public readonly context?: TContext;
+
+  constructor(code: TCode, message: string, context?: TContext) {
     super(message);
     this.name = this.constructor.name;
+    this.code = code;
+    this.context = context;
     Error.captureStackTrace(this, this.constructor);
   }
 
   static isInstance(error: unknown): error is DomainError {
     return error instanceof DomainError;
+  }
+
+  protected static create<T extends DomainError>(this: new (...args: never[]) => T, code: T["code"], opts?: DomainErrorOpts): T {
+    const message = opts?.message ?? (opts?.error instanceof Error ? opts.error.message : undefined);
+    type Ctor = new (code: T["code"], message?: string, context?: Record<string, unknown>) => T;
+    // biome-ignore lint/complexity/noThisInStatic: `this` is the late-bound subclass — required so static factories construct the right subclass.
+    const Ctor = this as Ctor;
+    return new Ctor(code, message, opts?.context);
   }
 }


### PR DESCRIPTION
> Stacked on top of #7. Review **after** #7 merges (or rebase this onto `main` after merge).

## Summary

Adopt the static-factory error pattern (used in our safari mobile codebase) so constructing domain errors stays concise as more protocols join. No wire-level change — same error codes, same HTTP statuses, same response envelope.

## What changed

### `shared/errors/base.error.ts` — new base
- `DomainError<TCode, TContext>` — generic, with typed `context`.
- `DomainErrorOpts<TContext>` — single options object `{ message?, error?, context? }`.
- `protected static create()` helper — late-bound `this` so subclasses get correctly-typed factories.
- **Intentionally NOT included:** `toJSON()`, `timestamp`, `ErrorHandler`. Wire serialization is owned by `shared/contracts/error.schema.ts` + `presentation/v1/error-mapper.ts`; this layer stays minimal.

### `features/uniswap-v3/domain/errors/position.error.ts`
- Static factories: `PositionError.POSITION_NOT_FOUND(opts)`, `.GRAPHQL_ERROR(opts)`, `.UNEXPECTED_ERROR(opts)`.
- Renamed `CODE` → `CODES` (consistency with the safari convention).
- `isInstance` narrowed to `PositionError`.

### Call sites
- `positions.repository.ts` (6 spots): every `catch` now forwards the caught error via `opts.error` (preserved as fallback message) and adds a meaningful `context` (`owner`, `positionId`, `poolAddress`, `positionCount`).
- `get-position.usecase.ts`: stop wrapping `poolStateResult.error` in a fresh `UNEXPECTED_ERROR` — pass it through. The real cause (RPC failure vs missing state) now survives all the way to the HTTP mapper.

## Before / after

```ts
// before
return err(new PositionError(PositionError.CODE.GRAPHQL_ERROR));

// after
return err(PositionError.GRAPHQL_ERROR({ error, context: { owner, ...pagination } }));
```

## Why now (not later)

We have exactly **one** `DomainError` subclass right now (`PositionError`). Adding Aerodrome will give us a second. Standardising the pattern with 1 class is a 4-file change; doing it with 4 classes spread across protocols would be 4× the work and 4× the review surface.

## Test plan

- [x] `bun run typecheck` (apps/server) — green
- [x] `bun run lint` — no new errors introduced (5 pre-existing warnings inherited from #7 baseline)
- [ ] Smoke: `GET /api/v1/positions/uniswap-v3:1:99999999999` still returns `404 POSITION_NOT_FOUND` (no behavior change expected)
- [ ] Smoke: trigger a subgraph failure (block GraphQL host) → `502 UPSTREAM_UNAVAILABLE` still rendered correctly

## Out of scope

- Wider rollout of the pattern (no other `DomainError` subclasses exist yet).
- Adding `toJSON()`/`timestamp`/`ErrorHandler` — only if a concrete need shows up.
- Mobile-side error handling — separate branch when mobile migrates to the v1 gateway.
