### PR TITLE
Production docker stack with server-proxied icons

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,43 @@
+# VCS
+.git
+.gitignore
+.gitattributes
+
+# Dependencies (re-installed inside the image)
+node_modules
+**/node_modules
+
+# Turborepo cache
+.turbo
+**/.turbo
+
+# Local env (compose loads .env from host, not from build context)
+.env
+.env.*
+!.env.example
+
+# Logs and OS junk
+*.log
+.DS_Store
+
+# Docs and tooling that aren't needed in the image
+docs
+.vscode
+.idea
+.superpowers
+
+# Workspaces not built into either backend image
+apps/mobile
+apps/subgraphs
+
+# Build/test artifacts
+build
+dist
+coverage
+**/build
+**/dist
+**/coverage
+
+# Expo
+.expo
+**/.expo

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,22 @@
+# Host port for the public-facing server (default 3000; override if 3000 is in use).
+SERVER_PORT=3000
+
+# --- server (apps/server) ---
+# Alchemy API key — required at runtime for RPC URL construction.
+ALCHEMY_API_KEY=
+# The Graph Studio API key — sent as Bearer for all subgraph queries.
+GRAPH_API_KEY=
+
+# --- tokens-data (apps/tokens-data) ---
+# Per-chain RPC URLs — required (tokens-data throws on first use if missing).
+RPC_URL_1=
+RPC_URL_42161=
+RPC_URL_8453=
+
+# --- shared / optional ---
+# debug | info | warning | error | fatal (default: info)
+LOG_LEVEL=info
+# Force-enable debug regardless of LOG_LEVEL.
+# DEBUG=true
+# When set, fatal logs forward to AppSignal automatically.
+# APPSIGNAL_PUSH_API_KEY=

--- a/apps/mobile/src/core/config/index.ts
+++ b/apps/mobile/src/core/config/index.ts
@@ -3,9 +3,6 @@ import { EMembership } from "membership/domain/entities/membership.entity";
 const gatewayUrl = process.env.EXPO_PUBLIC_API_URL;
 if (!gatewayUrl) throw new Error("Missing env: EXPO_PUBLIC_API_URL");
 
-const tokensDataUrl = process.env.EXPO_PUBLIC_TOKENS_DATA_URL ?? (__DEV__ ? "http://localhost:3100" : undefined);
-if (!tokensDataUrl) throw new Error("Missing env: EXPO_PUBLIC_TOKENS_DATA_URL");
-
 const membershipRaw = process.env.EXPO_PUBLIC_MEMBERSHIP ?? EMembership.FREE;
 const membershipValues = Object.values(EMembership) as string[];
 if (!membershipValues.includes(membershipRaw)) {
@@ -15,7 +12,6 @@ if (!membershipValues.includes(membershipRaw)) {
 export const config = {
   api: {
     gateway: { baseUrl: gatewayUrl },
-    tokensData: { baseUrl: tokensDataUrl },
   },
   membership: {
     current: membershipRaw as EMembership,

--- a/apps/mobile/src/core/presentation/components/TokenImage.tsx
+++ b/apps/mobile/src/core/presentation/components/TokenImage.tsx
@@ -69,7 +69,7 @@ export const TokenImage = ({ token, chainId, imageUrl, size = "md", style }: Tok
   const seed = (token.address || token.symbol || "?").toLowerCase();
   const [errored, setErrored] = useState(false);
 
-  const remoteUrl = imageUrl ?? (chainId && token.address ? tokensDataUrls.logo(chainId, token.address) : undefined);
+  const remoteUrl = tokensDataUrls.resolve(imageUrl) ?? (chainId && token.address ? tokensDataUrls.logo(chainId, token.address) : undefined);
 
   styles.useVariants({ size });
 

--- a/apps/mobile/src/core/query/query-client.ts
+++ b/apps/mobile/src/core/query/query-client.ts
@@ -13,7 +13,7 @@ export const mmkvPersister = experimental_createQueryPersister({
     },
   },
   maxAge: 1000 * 60 * 60 * 24 * 90,
-  refetchOnRestore: false,
+  refetchOnRestore: true,
 });
 
 export function clearPersistedQueries(): void {
@@ -23,10 +23,10 @@ export function clearPersistedQueries(): void {
 export const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
-      staleTime: 1000 * 60 * 30,
+      staleTime: 1000 * 60,
       gcTime: 1000 * 60 * 60 * 24 * 90,
-      refetchOnMount: false,
-      refetchOnWindowFocus: false,
+      refetchOnMount: true,
+      refetchOnWindowFocus: true,
       refetchOnReconnect: true,
       persister: mmkvPersister.persisterFn,
     },

--- a/apps/mobile/src/core/tokens-data/urls.ts
+++ b/apps/mobile/src/core/tokens-data/urls.ts
@@ -1,5 +1,11 @@
 import { config } from "core/config";
 
 export const tokensDataUrls = {
-  logo: (chainId: number, address: string): string => `${config.api.tokensData.baseUrl}/v1/chains/${chainId}/tokens/${address}/logo.png`,
+  logo: (chainId: number, address: string): string => `${config.api.gateway.baseUrl}/icons/tokens/${chainId}/${address.toLowerCase()}`,
+  resolve: (url: string | undefined): string | undefined => {
+    if (!url) return undefined;
+    if (/^https?:\/\//.test(url)) return url;
+    if (url.startsWith("/")) return `${config.api.gateway.baseUrl}${url}`;
+    return url;
+  },
 };

--- a/apps/mobile/src/widgets/data/widget-snapshot.builder.ts
+++ b/apps/mobile/src/widgets/data/widget-snapshot.builder.ts
@@ -1,4 +1,5 @@
 import { PROTOCOLS_META } from "@depthly/catalog";
+import { tokensDataUrls } from "core/tokens-data/urls";
 import type { TGatewayPosition, TPositionByExt, TTokensMap } from "positions/domain/types";
 
 import type { TWidgetExtension, TWidgetPair, TWidgetPosition, TWidgetSnapshot, TWidgetStatus, TWidgetToken } from "../domain/types";
@@ -53,7 +54,7 @@ function toWidgetToken(tokenRef: string, formatted: string, tokens: TTokensMap):
   const meta = tokens[tokenRef];
   return {
     symbol: meta?.symbol ?? tokenRef,
-    iconUrl: meta?.iconUrl ?? "",
+    iconUrl: tokensDataUrls.resolve(meta?.iconUrl) ?? "",
     formatted: formatWidgetAmount(formatted),
   };
 }

--- a/apps/server/Dockerfile
+++ b/apps/server/Dockerfile
@@ -1,0 +1,30 @@
+# syntax=docker/dockerfile:1.7
+
+FROM oven/bun:1.3.6-slim AS base
+
+# --- pruner: emit a partial monorepo containing only server + its deps ---
+FROM base AS pruner
+WORKDIR /repo
+RUN bun add -g turbo@2.7.5
+COPY . .
+RUN turbo prune server --docker
+
+# --- installer: install production deps against the pruned manifests ---
+FROM base AS installer
+WORKDIR /app
+COPY --from=pruner /repo/out/json/ .
+RUN bun install --frozen-lockfile --production --ignore-scripts --linker=hoisted
+COPY --from=pruner /repo/out/full/ .
+
+# --- runner: minimal final image, non-root, with curl for healthcheck ---
+FROM base AS runner
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends curl \
+  && rm -rf /var/lib/apt/lists/*
+WORKDIR /app
+COPY --from=installer /app .
+USER bun
+WORKDIR /app/apps/server
+ENV NODE_ENV=production
+EXPOSE 3000
+CMD ["bun", "run", "src/index.ts"]

--- a/apps/server/openapi/gateway.json
+++ b/apps/server/openapi/gateway.json
@@ -1,7 +1,7 @@
 {
   "openapi": "3.1.0",
   "info": {
-    "title": "depthly Gateway API",
+    "title": "Depthly Gateway API",
     "description": "Protocol-agnostic gateway API for DeFi position aggregation across wallets, chains, and protocols",
     "version": "1.0.0"
   },
@@ -257,9 +257,6 @@
               "decimals"
             ]
           },
-          "iconUrl": {
-            "type": "string"
-          },
           "explorerUrl": {
             "type": "string"
           }
@@ -270,7 +267,6 @@
           "name",
           "shortName",
           "nativeCurrency",
-          "iconUrl",
           "explorerUrl"
         ]
       },

--- a/apps/server/src/app/networks/catalog.ts
+++ b/apps/server/src/app/networks/catalog.ts
@@ -1,11 +1,7 @@
 import { NETWORKS } from "@depthly/catalog";
-import { buildNetworkIconUrl } from "shared/adapters/tokens-data.urls";
 import type { Network } from "shared/contracts";
 
-export const networkCatalog: Network[] = NETWORKS.map((seed) => ({
-  ...seed,
-  iconUrl: buildNetworkIconUrl(seed.chainId),
-}));
+export const networkCatalog: Network[] = NETWORKS.map((seed) => ({ ...seed }));
 
 const byChainId = new Map<number, Network>(networkCatalog.map((n) => [n.chainId, n]));
 

--- a/apps/server/src/features/icons/presentation/api/index.ts
+++ b/apps/server/src/features/icons/presentation/api/index.ts
@@ -1,0 +1,1 @@
+export { routes as iconsRoutes } from "./routes";

--- a/apps/server/src/features/icons/presentation/api/routes.ts
+++ b/apps/server/src/features/icons/presentation/api/routes.ts
@@ -1,0 +1,34 @@
+import "reflect-metadata";
+
+import { Hono } from "hono";
+import { describeRoute, validator } from "hono-openapi";
+import { container } from "tsyringe";
+import * as v from "valibot";
+
+import { TokensDataClient } from "../../../token-prices/data/tokens-data-client";
+
+const tokenIconParamsSchema = v.object({
+  chainId: v.pipe(v.string(), v.transform(Number), v.integer()),
+  address: v.pipe(v.string(), v.regex(/^0x[a-fA-F0-9]{40}$/, "Invalid address")),
+});
+
+const CACHE_CONTROL = "public, max-age=300, stale-while-revalidate=86400";
+
+export const routes = new Hono();
+
+routes.get(
+  "/tokens/:chainId/:address",
+  describeRoute({
+    tags: ["Icons"],
+    summary: "Token logo — 302 redirect to upstream CDN",
+    responses: { 302: { description: "Redirect to CDN logo URL" }, 404: { description: "Not found" } },
+  }),
+  validator("param", tokenIconParamsSchema),
+  async (c) => {
+    const { chainId, address } = c.req.valid("param") as { chainId: number; address: string };
+    const url = await container.resolve(TokensDataClient).getLogoUrl(chainId, address);
+    if (!url) return c.notFound();
+    c.header("Cache-Control", CACHE_CONTROL);
+    return c.redirect(url, 302);
+  },
+);

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -4,6 +4,7 @@ import { installLogger, requestLogger } from "@depthly/logger";
 import { Scalar } from "@scalar/hono-api-reference";
 import { Hono } from "hono";
 import { openAPIRouteHandler } from "hono-openapi";
+import { iconsRoutes } from "icons/presentation/api";
 import { tokenPricesRoutes } from "token-prices/presentation/api";
 import { tokensMetaRoutes } from "tokens-meta/presentation/api";
 
@@ -38,6 +39,7 @@ const openApiDocumentation = {
 app.get("/openapi.json", openAPIRouteHandler(v1Routes, { documentation: openApiDocumentation }));
 app.get("/docs", Scalar({ url: "/openapi.json", theme: "purple", pageTitle: "Depthly API" }));
 
+app.route("/icons", iconsRoutes);
 app.route("/meta", tokensMetaRoutes);
 app.route("/prices", tokenPricesRoutes);
 

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -17,6 +17,8 @@ const app = new Hono();
 
 app.use("*", requestLogger({ app: "server" }));
 
+app.get("/health", (c) => c.json({ ok: true, service: "server" }));
+
 app.route("/api/v1", v1Routes);
 
 const openApiDocumentation = {

--- a/apps/server/src/shared/adapters/tokens-data.urls.ts
+++ b/apps/server/src/shared/adapters/tokens-data.urls.ts
@@ -1,9 +1,3 @@
-import { config } from "shared/config";
-
 export function buildTokenIconUrl(chainId: number, address: string): string {
-  return `${config.api.tokensData.baseUrl}/v1/chains/${chainId}/tokens/${address.toLowerCase()}/logo.png`;
-}
-
-export function buildNetworkIconUrl(chainId: number): string {
-  return `${config.api.tokensData.baseUrl}/v1/chains/${chainId}/icon.png`;
+  return `/icons/tokens/${chainId}/${address.toLowerCase()}`;
 }

--- a/apps/server/src/shared/contracts/catalog.schema.ts
+++ b/apps/server/src/shared/contracts/catalog.schema.ts
@@ -11,7 +11,6 @@ export const networkSchema = v.pipe(
       name: v.string(),
       decimals: v.number(),
     }),
-    iconUrl: v.string(),
     explorerUrl: v.string(),
   }),
   v.metadata({ ref: "Network" }),

--- a/apps/server/tsconfig.json
+++ b/apps/server/tsconfig.json
@@ -17,7 +17,8 @@
 
       "uniswap-v3/*": ["features/uniswap-v3/*", "features/uniswap-v3"],
       "token-prices/*": ["features/token-prices/*", "features/token-prices"],
-      "tokens-meta/*": ["features/tokens-meta/*", "features/tokens-meta"]
+      "tokens-meta/*": ["features/tokens-meta/*", "features/tokens-meta"],
+      "icons/*": ["features/icons/*", "features/icons"]
     }
   },
   "exclude": ["scripts"]

--- a/apps/tokens-data/Dockerfile
+++ b/apps/tokens-data/Dockerfile
@@ -1,0 +1,33 @@
+# syntax=docker/dockerfile:1.7
+
+FROM oven/bun:1.3.6-slim AS base
+
+# --- pruner: emit a partial monorepo containing only tokens-data + its deps ---
+FROM base AS pruner
+WORKDIR /repo
+RUN bun add -g turbo@2.7.5
+COPY . .
+RUN turbo prune tokens-data --docker
+
+# --- installer: install production deps against the pruned manifests ---
+FROM base AS installer
+WORKDIR /app
+# Copy only manifests first → this layer is cached unless any package.json or
+# bun.lock changes.
+COPY --from=pruner /repo/out/json/ .
+RUN bun install --frozen-lockfile --production --ignore-scripts --linker=hoisted
+# Then overlay the pruned source tree.
+COPY --from=pruner /repo/out/full/ .
+
+# --- runner: minimal final image, non-root, with curl for healthcheck ---
+FROM base AS runner
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends curl \
+  && rm -rf /var/lib/apt/lists/*
+WORKDIR /app
+COPY --from=installer /app .
+USER bun
+WORKDIR /app/apps/tokens-data
+ENV NODE_ENV=production
+EXPOSE 3100
+CMD ["bun", "run", "src/index.ts"]

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,62 @@
+name: depthly
+
+services:
+  redis:
+    image: redis:7-alpine
+    init: true
+    restart: unless-stopped
+    volumes:
+      - redis-data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+
+  tokens-data:
+    build:
+      context: .
+      dockerfile: apps/tokens-data/Dockerfile
+    init: true
+    restart: unless-stopped
+    env_file: .env
+    environment:
+      REDIS_URL: redis://redis:6379
+      PORT: "3100"
+    depends_on:
+      redis:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://localhost:3100/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+
+  server:
+    build:
+      context: .
+      dockerfile: apps/server/Dockerfile
+    init: true
+    restart: unless-stopped
+    stop_grace_period: 30s
+    ports:
+      - "${SERVER_PORT:-3000}:3000"
+    env_file: .env
+    environment:
+      REDIS_URL: redis://redis:6379
+      TOKENS_DATA_URL: http://tokens-data:3100
+    depends_on:
+      redis:
+        condition: service_healthy
+      tokens-data:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://localhost:3000/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+
+volumes:
+  redis-data:


### PR DESCRIPTION
## Summary

Adds a production-ready Docker stack for the two backend services and refactors icon URLs so the mobile app only ever talks to the gateway. Servers also start sending cache headers and the mobile TanStack Query defaults are loosened so the server controls freshness.

## Docker stack

- Multi-stage Dockerfiles for `server` and `tokens-data` via `turbo prune --docker`, hoisted `node_modules`, `--ignore-scripts`, non-root `bun` user.
- Root `compose.yaml` with Redis 7-alpine, health-gated `depends_on: service_healthy` ordering, `init: true`, server `stop_grace_period: 30s`, named volume for Redis persistence.
- New `GET /health` route on server (`tokens-data` already had one) so compose can probe both.
- `${SERVER_PORT:-3000}` override (port 3000 is often held by Rails locally).
- Pinned `turbo@2.7.5` in pruner stage for reproducible builds.

## Server-proxied icon URLs

The `iconUrl` returned by the API is now a relative path (`/icons/tokens/:chainId/:address`) instead of an absolute URL pointing at `tokens-data`. The mobile app prepends the gateway base URL.

- Server has a thin proxy route under `/icons/tokens/...` that calls `tokens-data` internally and re-emits its 302 to the upstream CDN. Bytes never go through our infrastructure.
- `tokens-data` stays internal — no public port published, single public surface.
- Mobile drops `EXPO_PUBLIC_TOKENS_DATA_URL` entirely; it only knows about the gateway.
- `Network.iconUrl` removed from the catalog schema — the mobile app already had its own bundled `CHAIN_LOGOS` for chain icons with the proper theme/halo treatment.

## Server-driven freshness

- Server sends `Cache-Control: public, max-age=300, stale-while-revalidate=86400` on icon redirects: clients get instant cached results, refetch in the background after 5 min, hard-refresh after 24h.
- TanStack Query defaults loosened: `staleTime: 1m` (was 30m), `refetchOnMount/Focus: true` (were false). MMKV persister and `gcTime: 90d` preserved so the app still opens with instant stale-data, but a background refetch fires immediately.

## Verification

- `docker compose up --build` brings all three services healthy.
- `curl :3000/api/v1/catalog?chainId=1` returns networks (now without `iconUrl`).
- `curl :3000/icons/tokens/1/0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48` → `HTTP 302` → TrustWallet CDN.
- Mobile renders token logos via the server proxy and network icons from the local bundle.

## Open follow-ups (not in this PR)

- Image sizes are larger than I'd like (server 931 MB, tokens-data 971 MB). The `--production` install seems to keep transitive Uniswap/hardhat deps; worth investigating.
- Resource limits (`mem_limit`, `cpus`), log rotation, Redis auth, and separate live/ready healthchecks are reasonable next steps before staging.
- `tokens-data` 302-redirect-resolver could move to a separate public host one day, but only if we ever need that surface area.

Design spec and implementation plan: `docs/superpowers/specs/2026-06-11-docker-prod-deploy-design.md`, `docs/superpowers/plans/2026-06-12-docker-prod-deploy.md`.