### PR TITLE
ci: tighten deploy job permissions, prune flag and HTML cache matcher

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -80,6 +80,7 @@ jobs:
       url: https://depthly.xyz
     permissions:
       contents: read
+      packages: read
     steps:
       - name: Resolve image tag
         id: tag
@@ -152,6 +153,6 @@ jobs:
           echo "Public probe failed"
           exit 1
 
-      - name: Prune dangling images
+      - name: Prune unused images
         if: always()
-        run: docker image prune -f --filter "until=168h"
+        run: docker image prune -af --filter "until=168h"

--- a/apps/landing/Caddyfile
+++ b/apps/landing/Caddyfile
@@ -8,7 +8,7 @@
 	@hashed path_regexp ^/assets/.+\.[A-Za-z0-9]{8,}\.[a-z]+$
 	header @hashed Cache-Control "public, max-age=31536000, immutable"
 
-	@html path /index.html /
+	@html path / /index.html *.html
 	header @html Cache-Control "public, max-age=0, must-revalidate"
 
 	file_server


### PR DESCRIPTION
Three small hardening fixes surfaced by an architect review of the freshly
landed deploy pipeline.

## Changes

1. **Explicit `packages: read` on deploy job.** Workflow-level grants
   `packages: write`, but the deploy job's `permissions:` override only
   listed `contents: read`, which silently dropped the package scope. GHCR
   pulls happen to work today because of permission inheritance edge cases
   we'd rather not rely on. Made it explicit.

2. **`docker image prune -af` instead of `-f`.** The plain `-f` flag prunes
   only *dangling* images, but our sha-tagged layers are never dangling
   (they always have a tag). After enough deploys the Pi disk would slowly
   fill with stale `sha-...` images that the 168h filter would never catch.
   `-af` removes all unused tagged images older than the threshold.

3. **`@html` matcher covers `*.html`.** Previously `/` and `/index.html`
   only. Adding a `/pricing` or `/blog/post.html` page later would have
   left it without any `Cache-Control` header (Caddy would fall through to
   `file_server` with no header, browsers apply heuristic caching). Now
   any `.html` URL gets `max-age=0, must-revalidate`.

## Test plan

- [ ] Workflow re-runs cleanly on merge (build + deploy)
- [ ] Pi has no leftover sha-tagged images older than 168h after a few
      deploy cycles
- [ ] curl `https://depthly.xyz/anything.html` returns
      `cache-control: public, max-age=0, must-revalidate`